### PR TITLE
调整版本发布流程，以支持自动发布 NPM 版本

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Package to npmjs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      # Setup .npmrc file to publish to npm
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org'
+          # Defaults to the user or organization that owns the workflow file
+          # scope: '@cell-x'
+
+      - name: Install dependencies and Build package
+        run: npm ci
+
+      - name: Publish Package to npmjs
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Release for new tag
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    tags:
+      - 'v*.*.*'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 14
+      
+      - name: Install dependencies
+        run: npm ci
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          # Creates a draft release. Defaults to false
+          draft: true
+          # Newline-delimited list of path globs for asset files to upload
+          files: |
+            translate.js/translate.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dev/update-version.js
+++ b/dev/update-version.js
@@ -1,0 +1,1 @@
+console.log('test');

--- a/dev/update-version.js
+++ b/dev/update-version.js
@@ -1,1 +1,20 @@
-console.log('test');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const packageJson = require('../package.json');
+const translateJsPath = path.resolve(__dirname, '../translate.js/translate.js');
+const translateJs = fs.readFileSync(translateJsPath, 'utf-8');
+
+/**
+ * 把 packageJson.version 写入到 ../translate.js/translate.js 中的 version 字段
+ * translate.js 中的版本号格式：major.minor.patch.YYYYMMDD
+ */
+const dateSuffix = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+const translateJsVersion = `${packageJson.version}.${dateSuffix}`;
+const start = translateJs.indexOf('// AUTO_VERSION_START') + '// AUTO_VERSION_START'.length;
+const end = translateJs.indexOf('// AUTO_VERSION_END');
+const newTranslateJs = `${translateJs.slice(0, start)}\n  version: '${translateJsVersion}',\n  ${translateJs.slice(end)}`;
+fs.writeFileSync(translateJsPath, newTranslateJs, 'utf-8');
+
+// 添加更新的文件到 git stage
+execSync('git add translate.js/translate.js');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "i18n-jsautotranslate",
+  "version": "3.11.0",
+  "description": "Two lines of js realize automatic html translation. No need to change the page, no language configuration file, no API key, SEO friendly!",
+  "main": "translate.js/translate.js",
+  "scripts": {
+    "version": "node dev/update-version.js"
+  },
+  "keywords": [
+    "i18n",
+    "translatejs",
+    "i18n-translatejs"
+  ],
+  "files": [
+    "translate.js/translate.js"
+  ],
+  "author": "管雷鸣",
+  "license": "Apache-2.0"
+}

--- a/translate.js/translate.js
+++ b/translate.js/translate.js
@@ -6,10 +6,14 @@
 
  */ 
 var translate = {
-	/*
+	/**
 	 * 当前的版本
+   * 由 npm 脚本自动更新，无需手动修改
+   * 格式：major.minor.patch.date
 	 */
-	version:'3.11.0.20241206',
+  // AUTO_VERSION_START
+  version: '3.11.0.20241208',
+  // AUTO_VERSION_END
 	/*
 		当前使用的版本，默认使用v2. 可使用 setUseVersion2(); 
 		来设置使用v2 ，已废弃，主要是区分是否是v1版本来着，v2跟v3版本是同样的使用方式

--- a/translate.js/translate.js
+++ b/translate.js/translate.js
@@ -5423,3 +5423,19 @@ var nodeuuid = {
 
 }
 console.log('------ translate.js ------\nTwo lines of js html automatic translation, page without change, no language configuration file, no API Key, SEO friendly! Open warehouse : https://github.com/xnx3/translate \n两行js实现html全自动翻译。 无需改动页面、无语言配置文件、无API Key、对SEO友好！完全开源，代码仓库：https://gitee.com/mail_osc/translate');
+
+/**
+ * 兼容 AMD、CMD、CommonJS 规范
+ * node 环境使用：`npm i i18n-jsautotranslate` 安装包
+ */
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], () => factory());
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root['translate'] = factory();
+  }
+})(this, function () {
+  return translate;
+});


### PR DESCRIPTION
本次 PR 尽量不改动源码的前提下调整版本自动发布流程，修改后的流程为：

1. 本地开发完成
2. npm version 3.12.0 （这里设置具体的版本，不带v）
3. npm version hook 脚本处理 translate.js 中的版本号, 格式为：3.12.0-年月日（自动提交更新的文件）
4. 自动 push git tag v3.12.0
5. tag 推送时触发 github actions 自动发布 release 草稿
6. 手动更新 release 变动日志，点击发布 release
7. 发布 release 成功后 github actions 自动发布 npm 包

顺便提一下，看了下 `translate.js` 源码，实在太过于臃肿，未来应当适当拆分为多个 js，最后集成打包发布比较好。

---

> [!NOTE]
> 自动发布到 NPM，需要获取一个 token。

1. 选择 Classic token

    <img width="530" alt="image" src="https://github.com/user-attachments/assets/f57a9978-075e-47d3-9795-b3b20e5f4d4a">

2. 然后选择 Automation 后点生成即可，生成后复制 token

    <img width="530" alt="image" src="https://github.com/user-attachments/assets/384b664d-ba52-463c-8d45-b936a6bfaf9e">

3. 然后把复制的 token，填到本仓库的环境变量里，变量名为 `NPM_TOKEN`

    <img width="1124" alt="image" src="https://github.com/user-attachments/assets/364056f7-2c58-4e5d-87b5-159dadc143f4">
    
---

例如，先发个测试版本测试一下流程：

1. 提前在本地安装好 node
2. 本项目根目录执行 `npm version 3.12.0`
3. 推送本地所有提交和和刚刚生成的 tag，（`git push --tags`）
4. 到本仓库 release 应该会发现多出一个新版本的草稿，简单编辑一下内容点发布
5. 稍等一会，等 actions 执行完，在 NPM [i18n-jsautotranslate](https://www.npmjs.com/package/i18n-jsautotranslate?activeTab=versions) 就会多出一个新版本了
6. 至此，版本发布完成

@xnx3 你先试试看，发布流程上有没有问题，发一下测试版本（`3.12.0-beta`之类的），然后我测试一下这个包在 Vue 项目中是否正常。

到时候，在 Vue 中使用的流程应该要更新：https://translate.zvo.cn/42046.html
