### PR TITLE
feat: 支持 Web Component Shadow DOM 内容翻译

### DIFF
--- a/translate.js/translate.js
+++ b/translate.js/translate.js
@@ -2537,6 +2537,10 @@ var translate = {
 										translate.element.iframe.execute(mutation.addedNodes[ani]);
 									}
 								}
+								// 若新增元素带有 shadowRoot，注册监听（内容翻译由 whileNodes 穿透处理）
+								if(mutation.addedNodes[ani].shadowRoot){
+									translate.element.shadowComponent.observe(mutation.addedNodes[ani]);
+								}
 								if(addNodeName.length > 0 && translate.ignore.tag.indexOf(addNodeName) == -1){
 									// 使用现有的忽略机制检查节点
 									//var addedNode = mutation.addedNodes[ani];
@@ -2660,7 +2664,10 @@ var translate = {
 				}
 			}
 
-			
+			// 扫描页面中已存在的 shadow host，全部注册监听（含嵌套）
+			translate.element.shadowComponent.scanAndObserve();
+
+
 			//如果要对 input 的value进行翻译，那么还要监听 input 的 value 的值
 			if(typeof(translate.element.tagAttribute['input']) === 'object' && translate.element.tagAttribute['input'].attribute.indexOf('value') > -1){
 				translate.listener.input.start();
@@ -5070,6 +5077,44 @@ var translate = {
 			},
 		},
 
+		/*js translate.element.shadowComponent start*/
+		shadowComponent:{
+			/*
+				已被注册监听的 shadow host 集合。
+				WeakSet：O(1) 查找，shadow host 从 DOM 移除后自动回收，无内存泄漏。
+			*/
+			observedSet: new WeakSet(),
+
+			/*
+				对一个 shadow host 的 shadowRoot 注册 MutationObserver 监听。
+				前置条件：listener 已启动（translate.listener.observer 存在）。
+			*/
+			observe: function(shadowHost){
+				if(!shadowHost || !shadowHost.shadowRoot) return;
+				if(this.observedSet.has(shadowHost)) return;
+				if(!translate.listener.observer) return;
+				this.observedSet.add(shadowHost);
+				translate.listener.observer.observe(shadowHost.shadowRoot, translate.listener.config);
+			},
+
+			/*
+				从指定根节点向下扫描所有 shadow host 并注册监听。
+				递归处理嵌套 shadow DOM。
+				仅在 addListener 启动时调用一次。
+			*/
+			scanAndObserve: function(root){
+				root = root || document.documentElement;
+				var elements = root.querySelectorAll('*');
+				for(var i = 0; i < elements.length; i++){
+					if(elements[i].shadowRoot){
+						this.observe(elements[i]);
+						this.scanAndObserve(elements[i].shadowRoot);
+					}
+				}
+			}
+		},
+		/*js translate.element.shadowComponent end*/
+
 		/*js translate.element.iframe start*/
 		iframe:{
 			isUse:false, //是否启用，对非跨域的iframe的页面也进行自动翻译。true则是启用。默认是false为不启用
@@ -5396,7 +5441,16 @@ var translate = {
 				}
 			}
 
-			
+
+			// Shadow DOM 穿透：对含 shadowRoot 的元素，递归翻译其 shadow 内容，并注册监听
+			if(node.nodeType === 1 && node.shadowRoot){
+				var shadowChildNodes = node.shadowRoot.childNodes;
+				for(var si = 0; si < shadowChildNodes.length; si++){
+					translate.element.whileNodes(uuid, shadowChildNodes[si]);
+				}
+				translate.element.shadowComponent.observe(node);
+			}
+
 			var childNodes = node.childNodes;
 			if(childNodes == null || typeof(childNodes) == 'undefined'){
 				return;


### PR DESCRIPTION
## 问题描述

translate.js 目前无法翻译 Web Component 内部通过 `attachShadow()` 创建的 Shadow DOM 内容。原因在于：

- DOM 遍历使用 `node.childNodes`，无法穿透 Shadow DOM 边界
- `MutationObserver` 仅观察 Light DOM，Shadow DOM 内的动态变化无法被捕获

## 改动内容

新增 `translate.element.shadowComponent` 模块，共 4 处最小改动（56 行新增，不改动任何现有逻辑）：

1. **新增 `shadowComponent` 模块**：基于 `WeakSet` 实现防重复注册，`observe()` 将 shadowRoot 纳入现有 MutationObserver，`scanAndObserve()` 递归扫描嵌套 shadow host
2. **`whileNodes` 穿透 shadowRoot**：每次翻译扫描时自动进入 shadow DOM，天然支持任意嵌套深度
3. **`listener.callback` 检测动态新增的 shadow host**：Web Component 动态挂载时立即注册监听
4. **`addListener` 启动时扫描全页已有 shadow host**：弥补 listener 启动晚于组件挂载的时序差

## 覆盖场景

| 场景 | 支持情况 |
|------|---------|
| 初始翻译时已存在的 shadow DOM 内容 | ✅ |
| shadow DOM 内部动态渲染 | ✅ |
| Web Component 动态挂载后翻译 | ✅ |
| 嵌套 Web Component（任意深度） | ✅ |
| `closed` 模式 shadow root | ✅ 静默跳过，无副作用 |
| Slot 内容（Light DOM） | ✅ 现有逻辑已覆盖 |

## 性能

- `WeakSet.has()` O(1) 判重，shadow host 移除后自动 GC
- `node.shadowRoot` 属性读取 O(1)，每次 `whileNodes` 一次
- `scanAndObserve()` 仅在 listener 启动时执行一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)