### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/extend/bot/src/main/java/cn/zvo/translateai/config/WebSocketConfig.java
+++ b/extend/bot/src/main/java/cn/zvo/translateai/config/WebSocketConfig.java
@@ -17,6 +17,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(analysisHandler, "/ws/analysis")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins("http://localhost", "https://localhost");
     }
 }

--- a/extend/chrome_plugin/background.js
+++ b/extend/chrome_plugin/background.js
@@ -18,18 +18,17 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       func: () => document.body.innerHTML  
     });  
   
-    // 在页面头部添加翻译脚本  
-    const script = `  
-      var head = document.getElementsByTagName('head')[0];  
-      var scriptElement = document.createElement('script');  
-      scriptElement.type = 'text/javascript';  
-      scriptElement.src = 'https://res.zvo.cn/translate/inspector_v2.js';  
-      head.appendChild(scriptElement);  
-    `;  
-    await chrome.scripting.executeScript({  
-      target: {tabId: currentTab.id},  
-      code: script  
-    }); 
+    // 在页面头部添加翻译脚本
+    await chrome.scripting.executeScript({
+      target: {tabId: currentTab.id},
+      func: () => {
+        var head = document.getElementsByTagName('head')[0];
+        var scriptElement = document.createElement('script');
+        scriptElement.type = 'text/javascript';
+        scriptElement.src = 'https://res.zvo.cn/translate/inspector_v2.js';
+        head.appendChild(scriptElement);
+      }
+    });
 
     
    /*  translate.listener.start(); 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `extend/chrome_plugin/background.js:L35`

The background.js file uses chrome.scripting.executeScript with a string 'code' parameter containing dynamically constructed JavaScript. This is equivalent to eval() and can lead to code injection if any part of the injected script is influenced by attacker-controlled data. The script URL is hardcoded but the pattern itself is dangerous.

## Solution

Use the 'func' property instead of 'code' in chrome.scripting.executeScript, passing a function reference rather than a string. This avoids eval-like behavior.

## Changes

- `extend/chrome_plugin/background.js` (modified)
- `extend/bot/src/main/java/cn/zvo/translateai/config/WebSocketConfig.java` (modified)